### PR TITLE
remove/change from_params to be compatible with AllenNLP 0.6.0

### DIFF
--- a/newsgroups/dataset_readers/fetch_newsgroups.py
+++ b/newsgroups/dataset_readers/fetch_newsgroups.py
@@ -85,11 +85,4 @@ class NewsgroupsDatasetReader(DatasetReader):
             fields['label'] = LabelField(int(target),skip_indexing=True)
         return Instance(fields)
 
-    @classmethod
-    def from_params(cls, params: Params) -> 'NewsgroupsDatasetReader':
-        tokenizer = Tokenizer.from_params(params.pop('tokenizer', {}))
-        token_indexers = TokenIndexer.dict_from_params(params.pop('token_indexers', {}))
-        params.assert_empty(cls.__name__)
-        return cls(tokenizer=tokenizer, token_indexers=token_indexers)
-
 

--- a/newsgroups/models/newsgroups_classifier.py
+++ b/newsgroups/models/newsgroups_classifier.py
@@ -122,7 +122,7 @@ class Fetch20NewsgroupsClassifier(Model):
     @classmethod
     def from_params(cls, vocab: Vocabulary, params: Params) -> 'Fetch20NewsgroupsClassifier':
         embedder_params = params.pop("model_text_field_embedder")
-        model_text_field_embedder = TextFieldEmbedder.from_params(vocab, embedder_params)
+        model_text_field_embedder = TextFieldEmbedder.from_params(embedder_params, vocab=vocab)
         internal_text_encoder = Seq2VecEncoder.from_params(params.pop("internal_text_encoder"))
         classifier_feedforward = FeedForward.from_params(params.pop("classifier_feedforward"))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-allennlp==0.3
+allennlp==0.6.0


### PR DESCRIPTION
I remove/change from_params to make the code be compatible with AllenNLP 0.6.0 which removed `from_params()` and `dict_from_params()`